### PR TITLE
Support of WAR library updates + "Jenkins WAR - All Latest"

### DIFF
--- a/demo/all-latest-core/README.md
+++ b/demo/all-latest-core/README.md
@@ -1,0 +1,17 @@
+Jenkins WAR Packager Demo. All-latest core
+===
+
+This demo builds a Jenkins WAR which includes...
+
+* Master branch of the Jenkins core
+* Latest versions of Stapler, Remoting and XStream
+* Latest versions of some modules (full list - TODO)
+  * Some slave installer modules have obsolete tooling, they need to be updated before inclusion
+* Latest version of Lib Task Reactor
+
+
+Limitations:
+
+* Only component JARs are updated, the builder does not update dependencies
+* WAR Packager is able to replace/add libs to WEB-INF/lib only, components
+like Extras Executable War cannot be updated right now

--- a/demo/all-latest-core/build.sh
+++ b/demo/all-latest-core/build.sh
@@ -1,0 +1,2 @@
+java -jar ../../war-packager-cli/target/war-packager-cli-1.0-SNAPSHOT-jar-with-dependencies.jar \
+ -configPath packager-config.yml

--- a/demo/all-latest-core/packager-config.yml
+++ b/demo/all-latest-core/packager-config.yml
@@ -20,10 +20,11 @@ libPatches:
     artifactId: "remoting"
     source:
       git: https://github.com/jenkinsci/remoting.git
-  - groupId: "com.thoughtworks.xstream"
-    artifactId: "xstream"
-    source:
-      git: https://github.com/jenkinsci/xstream.git
+# XStream Repo has corrupted versioning, it cannot be packaged and bundled properly
+#  - groupId: "com.thoughtworks.xstream"
+#    artifactId: "xstream"
+#    source:
+#      git: https://github.com/jenkinsci/xstream.git
   - groupId: "org.kohsuke.stapler"
     artifactId: "stapler"
     source:
@@ -44,16 +45,21 @@ libPatches:
     artifactId: "bytecode-compatibility-transformer"
     source:
       git: https://github.com/jenkinsci/bytecode-compatibility-transformer.git
+  - groupId: "org.kohsuke"
+    artifactId: "asm6"
+    source:
+      version: 6.0_BETA
   # TODO: this one is bad idea, because it may require higher SSHD version (which we do not bump).
   # TODO: dependency resolution in WAR patcher?
   - groupId: "org.jenkins-ci.modules"
     artifactId: "sshd"
     source:
       git: https://github.com/jenkinsci/sshd-module.git
-  - groupId: "org.jenkins-ci.modules"
-    artifactId: "instance-identity"
-    source:
-      git: https://github.com/jenkinsci/instance-identity-module.git
+# TODO: Enable once master branch is fixed
+#  - groupId: "org.jenkins-ci.modules"
+#    artifactId: "instance-identity"
+#    source:
+#      git: https://github.com/jenkinsci/instance-identity-module.git
   - groupId: "org.jenkins-ci.modules"
     artifactId: "slave-installer"
     source:
@@ -62,6 +68,9 @@ libPatches:
     artifactId: "windows-slave-installer"
     source:
       git: https://github.com/jenkinsci/windows-slave-installer-module.git
+libExcludes:
+  - groupId: "org.kohsuke"
+    artifactId: "asm5"
 systemProperties: {
     jenkins.model.Jenkins.slaveAgentPort: "50000",
     jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/demo/all-latest-core/packager-config.yml
+++ b/demo/all-latest-core/packager-config.yml
@@ -1,0 +1,70 @@
+bundle:
+  groupId: "io.github.oleg-nenashev"
+  artifactId: "mywar"
+  vendor: "Jenkins project"
+  title: "Jenkins WAR - all latest"
+  description: "Just a Jenkins WAR, which includes all latest libs from master branches"
+war:
+  groupId: "org.jenkins-ci.main"
+  artifactId: "jenkins-war"
+  source:
+    git: https://github.com/jenkinsci/jenkins
+# You can add new libraries or replace existing ones
+#TODO: this thing demonstrates that it is a bad idea to include modules in such WAY. BOMs should be used instead
+libPatches:
+  - groupId: "org.jenkins-ci"
+    artifactId: "task-reactor"
+    source:
+      git: https://github.com/jenkinsci/lib-task-reactor.git
+  - groupId: "org.jenkins-ci.main"
+    artifactId: "remoting"
+    source:
+      git: https://github.com/jenkinsci/remoting.git
+  - groupId: "com.thoughtworks.xstream"
+    artifactId: "xstream"
+    source:
+      git: https://github.com/jenkinsci/xstream.git
+  - groupId: "org.kohsuke.stapler"
+    artifactId: "stapler"
+    source:
+      git: https://github.com/stapler/stapler.git
+  - groupId: "org.kohsuke.stapler"
+    artifactId: "stapler-groovy"
+    source:
+      git: https://github.com/stapler/stapler.git
+  - groupId: "org.kohsuke.stapler"
+    artifactId: "stapler-jelly"
+    source:
+      git: https://github.com/stapler/stapler.git
+  - groupId: "org.kohsuke.stapler"
+    artifactId: "stapler-jrebel"
+    source:
+      git: https://github.com/stapler/stapler.git
+  - groupId: "org.jenkins-ci"
+    artifactId: "bytecode-compatibility-transformer"
+    source:
+      git: https://github.com/jenkinsci/bytecode-compatibility-transformer.git
+  # TODO: this one is bad idea, because it may require higher SSHD version (which we do not bump).
+  # TODO: dependency resolution in WAR patcher?
+  - groupId: "org.jenkins-ci.modules"
+    artifactId: "sshd"
+    source:
+      git: https://github.com/jenkinsci/sshd-module.git
+  - groupId: "org.jenkins-ci.modules"
+    artifactId: "instance-identity"
+    source:
+      git: https://github.com/jenkinsci/instance-identity-module.git
+  - groupId: "org.jenkins-ci.modules"
+    artifactId: "slave-installer"
+    source:
+      git: https://github.com/jenkinsci/slave-installer-module.git
+  - groupId: "org.jenkins-ci.modules"
+    artifactId: "windows-slave-installer"
+    source:
+      git: https://github.com/jenkinsci/windows-slave-installer-module.git
+systemProperties: {
+    jenkins.model.Jenkins.slaveAgentPort: "50000",
+    jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}
+
+# TODO: Support System Groovy Scripts Bundling
+

--- a/demo/all-latest-core/run.sh
+++ b/demo/all-latest-core/run.sh
@@ -1,0 +1,2 @@
+JENKINS_HOME=$(pwd)/work java -jar tmp/output/target/mywar-1.0-SNAPSHOT.war --httpPort=8080 --prefix=/jenkins
+

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <module>war-packager-lib</module>
     <module>war-packager-cli</module>
     <module>war-packager-maven-plugin</module>
-    <module>demo/external-logging-elasticsearch</module>
   </modules>
 
   <licenses>

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -31,6 +31,8 @@ public class Config {
     public DependencyInfo war;
     public Collection<DependencyInfo> plugins;
     @CheckForNull
+    public Collection<DependencyInfo> libPatches;
+    @CheckForNull
     public Map<String, String> systemProperties;
     @CheckForNull
     public Collection<GroovyHookInfo> groovyHooks;

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -34,6 +34,8 @@ public class Config {
     @CheckForNull
     public Collection<DependencyInfo> libPatches;
     @CheckForNull
+    public Collection<DependencyInfo> libExcludes;
+    @CheckForNull
     public Map<String, String> systemProperties;
     @CheckForNull
     public Collection<GroovyHookInfo> groovyHooks;

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/config/Config.java
@@ -29,6 +29,7 @@ public class Config {
     public BuildSettings buildSettings;
     public PackageInfo bundle;
     public DependencyInfo war;
+    @CheckForNull
     public Collection<DependencyInfo> plugins;
     @CheckForNull
     public Collection<DependencyInfo> libPatches;

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -54,8 +54,10 @@ public class Builder {
 
         // Build core and plugins
         buildIfNeeded(config.war);
-        for (DependencyInfo plugin : config.plugins) {
-            buildIfNeeded(plugin);
+        if (config.plugins != null) {
+            for (DependencyInfo plugin : config.plugins) {
+                buildIfNeeded(plugin);
+            }
         }
 
         // Prepare library patches

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/Builder.java
@@ -94,6 +94,7 @@ public class Builder {
                 .removeMetaInf()
                 .addSystemProperties(config.systemProperties)
                 .replaceLibs(versionOverrides)
+                .excludeLibs()
                 .addHooks(hooks);
 
         File warOutputDir = new File(tmpDir, "output");

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/JenkinsWarPatcher.java
@@ -92,47 +92,93 @@ public class JenkinsWarPatcher {
         return this;
     }
 
+    private File getLibsDir() {
+        return new File(dstDir, "WEB-INF/lib");
+    }
+
     public JenkinsWarPatcher replaceLibs(Map<String, String> versionOverrides) throws IOException, InterruptedException {
         if (config.libPatches == null) {
             // nothing to replace
             return this;
         }
 
-        File libsDir = new File(dstDir, "WEB-INF/lib");
         for (DependencyInfo lib : config.libPatches) {
-            String effectiveVersion = versionOverrides.get(lib.artifactId);
-            if (effectiveVersion == null) {
-                if (!lib.source.isReleasedVersion()) {
-                    throw new IOException("Cannot resolve new version for library " + lib);
-                }
-                effectiveVersion = lib.source.version;
-            }
-
-            List<Path> paths = Files.find(libsDir.toPath(), 1, (path, basicFileAttributes) -> {
-                //TODO: this matcher is a bit lame, it may suffer from false positives
-                if (String.valueOf(path.getFileName()).startsWith(lib.artifactId)) {
-                    return true;
-                }
-                return false;
-            }).collect(Collectors.toList());
-            if (paths.size() > 1) {
-                throw new IOException("Bug in Jenkins WAR Packager, cannot find unique lib JAR for artifact " + lib.artifactId
-                    + ". Candidates: " + StringUtils.join(paths, ","));
-            } else if (paths.size() == 1) {
-                Path oldFile = paths.get(0);
-                LOGGER.log(Level.INFO, "Replacing the existing library {0} by version {1}. Original File: {2}",
-                        new Object[] {lib.artifactId, effectiveVersion, oldFile.getFileName()});
-                Files.delete(oldFile);
-            } else {
-                LOGGER.log(Level.INFO, "Adding new library {0} with version {1}",
-                        new Object[] {lib.artifactId, effectiveVersion});
-            }
-
-            File newJarFile = new File(libsDir, lib.artifactId + "-" + effectiveVersion + ".jar");
-            MavenHelper.downloadArtifact(dstDir, lib, effectiveVersion, newJarFile);
+            replaceLib(lib, versionOverrides);
         }
 
         return this;
+    }
+
+    public JenkinsWarPatcher excludeLibs() throws IOException, InterruptedException {
+        if (config.libExcludes == null) {
+            // nothing to remove
+            return this;
+        }
+
+        for (DependencyInfo lib : config.libExcludes) {
+            excludeLib(lib);
+        }
+
+        return this;
+    }
+
+    private void replaceLib(DependencyInfo lib, Map<String, String> versionOverrides) throws IOException, InterruptedException {
+
+        File libsDir = getLibsDir();
+        String effectiveVersion = versionOverrides.get(lib.artifactId);
+        if (effectiveVersion == null) {
+            if (!lib.source.isReleasedVersion()) {
+                throw new IOException("Cannot resolve new version for library " + lib);
+            }
+            effectiveVersion = lib.source.version;
+        }
+
+        List<Path> paths = Files.find(libsDir.toPath(), 1, (path, basicFileAttributes) -> {
+            //TODO: this matcher is a bit lame, it may suffer from false positives
+            String fileName = String.valueOf(path.getFileName());
+            if (fileName.matches(lib.artifactId + "-\\d+.*")) {
+                return true;
+            }
+            return false;
+        }).collect(Collectors.toList());
+        if (paths.size() > 1) {
+            throw new IOException("Bug in Jenkins WAR Packager, cannot find unique lib JAR for artifact " + lib.artifactId
+                    + ". Candidates: " + StringUtils.join(paths, ","));
+        } else if (paths.size() == 1) {
+            Path oldFile = paths.get(0);
+            LOGGER.log(Level.INFO, "Replacing the existing library {0} by version {1}. Original File: {2}",
+                    new Object[] {lib.artifactId, effectiveVersion, oldFile.getFileName()});
+            Files.delete(oldFile);
+        } else {
+            LOGGER.log(Level.INFO, "Adding new library {0} with version {1}",
+                    new Object[] {lib.artifactId, effectiveVersion});
+        }
+
+        File newJarFile = new File(libsDir, lib.artifactId + "-" + effectiveVersion + ".jar");
+        MavenHelper.downloadArtifact(dstDir, lib, effectiveVersion, newJarFile);
+    }
+
+    private void excludeLib(DependencyInfo lib) throws IOException, InterruptedException {
+        File libsDir = getLibsDir();
+        List<Path> paths = Files.find(libsDir.toPath(), 1, (path, basicFileAttributes) -> {
+            //TODO: this matcher is a bit lame, it may suffer from false positives
+            String fileName = String.valueOf(path.getFileName());
+            if (fileName.matches(lib.artifactId + "-\\d+.*")) {
+                return true;
+            }
+            return false;
+        }).collect(Collectors.toList());
+        if (paths.size() > 1) {
+            throw new IOException("Bug in Jenkins WAR Packager, cannot find unique lib JAR for artifact " + lib.artifactId
+                    + ". Candidates: " + StringUtils.join(paths, ","));
+        } else if (paths.size() == 1) {
+            Path oldFile = paths.get(0);
+            LOGGER.log(Level.INFO, "Removing library {0}. Original File: {1}",
+                    new Object[] {lib.artifactId, oldFile.getFileName()});
+            Files.delete(oldFile);
+        } else {
+            throw new IOException("Cannot remove library " + lib + ". It is missing in the WAR file");
+        }
     }
 
     public JenkinsWarPatcher addHooks(@Nonnull Map<String, File> hooks) throws IOException {

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/impl/MavenHPICustomWARPOMGenerator.java
@@ -50,10 +50,12 @@ public class MavenHPICustomWARPOMGenerator {
         model.addDependency(dep);
 
         // Plugins
-        for (DependencyInfo plugin : config.plugins) {
-            Dependency pluginDep = plugin.toDependency(versionOverrides);
-            pluginDep.setScope("runtime");
-            model.addDependency(pluginDep);
+        if (config.plugins != null) {
+            for (DependencyInfo plugin : config.plugins) {
+                Dependency pluginDep = plugin.toDependency(versionOverrides);
+                pluginDep.setScope("runtime");
+                model.addDependency(pluginDep);
+            }
         }
 
         // Maven HPI Plugin

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/MavenHelper.java
@@ -1,0 +1,35 @@
+package io.jenkins.tools.warpackager.lib.util;
+
+import io.jenkins.tools.warpackager.lib.config.DependencyInfo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.processFor;
+import static io.jenkins.tools.warpackager.lib.util.SystemCommandHelper.runFor;
+
+/**
+ * @author Oleg Nenashev
+ */
+public class MavenHelper {
+
+    private MavenHelper() {}
+
+    public static boolean artifactExists(File buildDir, DependencyInfo dep, String version) throws IOException, InterruptedException {
+        String gai = dep.groupId + ":" + dep.artifactId + ":" + version;
+        int res = runFor(buildDir, "mvn", "dependency:get", "-Dartifact=" + gai, "-Dtransitive=false", "-o");
+        return res == 0;
+    }
+
+    public static void downloadArtifact(File buildDir, DependencyInfo dep, String version, File destination)
+            throws IOException, InterruptedException {
+        String gai = dep.groupId + ":" + dep.artifactId + ":" + version;
+        processFor(buildDir, "mvn", "com.googlecode.maven-download-plugin:download-maven-plugin:1.4.0:artifact",
+                "-DgroupId=" + dep.groupId,
+                "-DartifactId=" + dep.artifactId,
+                "-Dversion=" + version,
+                "-DoutputDirectory=" + destination.getParentFile().getAbsolutePath(),
+                "-DoutputFileName=" + destination.getName());
+    }
+}

--- a/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
+++ b/war-packager-lib/src/main/java/io/jenkins/tools/warpackager/lib/util/SystemCommandHelper.java
@@ -1,0 +1,43 @@
+package io.jenkins.tools.warpackager.lib.util;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+/**
+ * @author Oleg Nenashev
+ * @since TODO
+ */
+public class SystemCommandHelper {
+
+    private SystemCommandHelper() {}
+
+    public static void processFor(File buildDir, String ... args) throws IOException, InterruptedException {
+        ProcessBuilder bldr = new ProcessBuilder(args).inheritIO();
+        int res = runFor(buildDir, args);
+        if (res != 0) {
+            throw new IOException("Command failed with exit code " + res + ": " + StringUtils.join(bldr.command(), ' '));
+        }
+    }
+
+    public static int runFor(File buildDir, String ... args) throws IOException, InterruptedException {
+        ProcessBuilder bldr = new ProcessBuilder(args).inheritIO();
+        bldr.directory(buildDir);
+        return bldr.start().waitFor();
+    }
+
+    public static String readFor(File buildDir, String ... args) throws IOException, InterruptedException {
+        ProcessBuilder bldr = new ProcessBuilder(args);
+        bldr.directory(buildDir);
+        Process proc = bldr.start();
+        int res = proc.waitFor();
+        String out = IOUtils.toString(proc.getInputStream(), Charset.defaultCharset()).trim();
+        if (res != 0) {
+            throw new IOException("Command failed with exit code " + res + ": " + StringUtils.join(bldr.command(), ' ') + ". " + out);
+        }
+        return out;
+    }
+}

--- a/war-packager-lib/src/main/resources/io/jenkins/tools/warpackager/lib/config/sample.yml
+++ b/war-packager-lib/src/main/resources/io/jenkins/tools/warpackager/lib/config/sample.yml
@@ -19,6 +19,11 @@ plugins:
     source:
       git: https://github.com/jglick/durable-task-plugin.git
       branch: watch-JENKINS-38381
+libPatches:
+  - groupId: "org.jenkins-ci"
+    artifactId: "task-reactor"
+    source:
+      git: https://github.com/jenkinsci/lib-task-reactor.git
 systemProperties: {
     jenkins.model.Jenkins.slaveAgentPort: "50000",
     jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}


### PR DESCRIPTION
- [x] - "plugins" section in Config YAML is now optional
- [x] - WAR Packager is now able to add libraries to WAR or to replace existing libraries
- [x] - Add Demo, which builds Jenkins WAR from latest components

Limitations:

* Although it works, it is actually a big proof for the [JENKINS-48578](https://issues.jenkins-ci.org/browse/JENKINS-48578) story (Jenkins WAR BOM). It would be more natural to just rebuild the WAR/Core from BOM then to apply such hacks
* No dependency management, should be done later via Jenkins core BOM
